### PR TITLE
changed documentation and made read_abf compatible with other import

### DIFF
--- a/oscillation.py
+++ b/oscillation.py
@@ -16,7 +16,7 @@ def create_epoch(df, window, step):
 
     Parameters
     ----------
-    df:
+    df: DataFrame
         Pandas Dataframe from 'read_abf' function.
     window: int
         Epoch size based on array index.
@@ -26,8 +26,9 @@ def create_epoch(df, window, step):
 
     Returns
     -------
-    Multiindexed Pandas DataFrame with column names unchanged and an
-    added index level named 'epoch.'
+    epoch_df: DataFrame
+        Multiindexed Pandas DataFrame with column names unchanged and
+        an added index level named 'epoch.'
 
     Notes
     -----
@@ -69,7 +70,7 @@ def epoch_hist(epoch_df, channel, hist_min, hist_max, num_bins):
 
     Parameters
     ----------
-    epoch_df:
+    epoch_df: DataFrame
         Dataframe from 'create_epoch' function.
     channel: str
         Channel column to be analyzed.
@@ -82,13 +83,15 @@ def epoch_hist(epoch_df, channel, hist_min, hist_max, num_bins):
 
     Returns
     -------
-    Multiindexed Pandas DataFrame with index levels unchanged, but with
-    an added column specifiying the bin for each value.
+    df: DataFrame
+        Multiindexed Pandas DataFrame with index levels unchanged, but
+        with an added column specifiying the bin for each value.
 
     Notes
     -----
     'bins' column contains the 'leftmost' (smallest?) bin edge.
     """
+    
     hist_arrays = []
     bin_arrays = []
     sweep_names = epoch_df.index.levels[0].values
@@ -120,7 +123,7 @@ def epoch_kde(epoch_df, channel, range_min, range_max, resolution=None):
 
     Parameters
     ----------
-    epoch_df:
+    epoch_df: Dataframe
         Dataframe from 'create_epoch' function.
     channel: str
         Channel column to be analyzed.
@@ -134,10 +137,11 @@ def epoch_kde(epoch_df, channel, range_min, range_max, resolution=None):
 
     Returns
     -------
-    Multiindexed Pandas DataFrame with index levels unchanged, but with
-    an added column specifiying the x value for each corresponding
-    density value (similar to the 'bin' in the histogram function, but
-        not the same)
+    df: Dataframe
+        Multiindexed Pandas DataFrame with index levels unchanged, but
+        with an added column specifiying the x value for each
+        corresponding density value (similar to the 'bin' in the
+        histogram function, but not exactly the same)
 
     References
     ----------
@@ -180,7 +184,7 @@ def epoch_pgram(epoch_df, channel, fs=10e3):
 
     Parameters
     ----------
-    epoch_df:
+    epoch_df: Dataframe
         Dataframe from 'create_epoch' function.
     channel: str
         Channel column to be analyzed.
@@ -189,7 +193,10 @@ def epoch_pgram(epoch_df, channel, fs=10e3):
 
     Returns
     -------
-    Multiindexed Pandas DataFrame.
+    df: Dataframe
+        Multiindexed Pandas DataFrame with the estimated power spectral
+        density (V^2/Hz) and frequency as the new column names. All
+        indexing from the input DataFrame remain unchanged. 
 
     References
     ----------
@@ -199,7 +206,6 @@ def epoch_pgram(epoch_df, channel, fs=10e3):
     pgram_f_arrays = []
     pgram_den_arrays = []
     fs = int(fs)
-
     sweep_names = epoch_df.index.levels[0].values
     epoch_names = epoch_df.index.levels[1].values
     total_epochs = len(sweep_names)*len(epoch_names)

--- a/read_abf.py
+++ b/read_abf.py
@@ -16,9 +16,10 @@ def read_abf(filename):
     filename: str
         filename WITH '.abf' extension
 
-    Return
-    ------
-    Pandas DataFrame brokend down by sweep
+    Returns
+    ------_
+    df: DataFrame
+        Pandas DataFrame broken down by sweep
 
     References
     ----------
@@ -28,19 +29,21 @@ def read_abf(filename):
     r = io.AxonIO(filename = filename)
     bl = r.read_block(lazy=False, cascade=True)
     num_channels = len(bl.segments[0].analogsignals)
-    channels = []
+    channels = ['Primary']
     signals = []
     df_list = []
     sweep_list = []
 
     for seg_num, seg in enumerate(bl.segments):
         for i in range(num_channels):
-            channels.append('channel_' + str(i))
             signals.append(bl.segments[seg_num].analogsignals[i])
+            if i >= 1:
+                channels.append('channel_' + str(i))
         data_dict = dict(zip(channels, signals))
         time = seg.analogsignals[0].times - seg.analogsignals[0].times[0]
         data_dict['time'] = time
         df = pd.DataFrame(data_dict)
         df_list.append(df)
         sweep_list.append('sweep' + str(seg_num + 1).zfill(3))
-    return pd.concat(df_list, keys=sweep_list, names=['sweep'])
+        df = pd.concat(df_list, keys=sweep_list, names=['sweep'])
+    return df


### PR DESCRIPTION
Made some minor documentation changes to keep it as consistent as possible between my code and Dan's. 

I also changed the read_abf import function compatible with Dan's 'pv_read' in the sense that the first column of data will always be referred to as 'Primary' with all other non-time columns to follow being named an iteration of 'channel_x.'
